### PR TITLE
Justin holiday controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/PublicHolidaysController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/PublicHolidaysController.java
@@ -1,9 +1,39 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.http.ResponseEntity;
 
+import edu.ucsb.cs156.spring.backenddemo.services.PublicHolidayQueryService;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Tag(name="Public Holiday info from Nager.Date API")
 @RestController
+@RequestMapping("/api/publicholidays")
 public class PublicHolidaysController {
     
+    @Autowired
+    PublicHolidayQueryService publicHolidayQueryService;
+
+    @Operation(summary = "Get public holidays for a given country and year", description = "JSON return format documented at https://date.nager.at/Api")
+    @GetMapping("/get")
+    public ResponseEntity<String> getPublicHolidays(
+        @Parameter(name="countryCode", description="Country Code", example="US") @RequestParam String countryCode,
+        @Parameter(name="year", description="Year", example="2024") @RequestParam String year
+    ) throws JsonProcessingException {
+        log.info("getPublicHolidays: year={}, countryCode={}", year, countryCode);
+        String result = publicHolidayQueryService.getJSON(year, countryCode);
+        return ResponseEntity.ok().body(result);
+    }
+
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryService.java
@@ -1,11 +1,20 @@
 package edu.ucsb.cs156.spring.backenddemo.services;
 
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.springframework.web.client.RestTemplate;
 
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
-
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
@@ -13,19 +22,27 @@ import org.springframework.web.client.HttpClientErrorException;
 @Service
 public class PublicHolidayQueryService {
 
-
+    ObjectMapper mapper = new ObjectMapper();
+    
     private final RestTemplate restTemplate;
 
     public PublicHolidayQueryService(RestTemplateBuilder restTemplateBuilder) {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = " https://date.nager.at/api/v2/publicholidays/{year}/{countryCode}";
+    public static final String ENDPOINT = "https://date.nager.at/api/v2/publicholidays/{year}/{countryCode}";
 
     public String getJSON(String year, String countryCode) throws HttpClientErrorException {
-        return "";
+        log.info("year={}, countryCode={}", year, countryCode);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, String> uriVariables = Map.of("year", year, "countryCode", countryCode);
+
+        HttpEntity<String> entity = new HttpEntity<>("body", headers);
+
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class, uriVariables);
+        return re.getBody();
     }
-
-   
-
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryService.java
@@ -20,7 +20,7 @@ public class PublicHolidayQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = " https://date.nager.at/api/v2/publicholidays/{year}/{countryCode}";
 
     public String getJSON(String year, String countryCode) throws HttpClientErrorException {
         return "";

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/PublicHolidayQueryControllerTest.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/PublicHolidayQueryControllerTest.java
@@ -1,0 +1,44 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import edu.ucsb.cs156.spring.backenddemo.services.PublicHolidayQueryService;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+
+@WebMvcTest(value = PublicHolidaysController.class)
+public class PublicHolidayQueryControllerTest{
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    PublicHolidayQueryService mockPublicHolidayQueryService;
+
+    @Test
+    public void test_getPublicHolidays() throws Exception {
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+        String countryCode = "US";
+        String year = "2024";
+        when(mockPublicHolidayQueryService.getJSON(eq(year), eq(countryCode))).thenReturn(fakeJsonResult);
+
+        String url = String.format("/api/publicholidays/get?countryCode=%s&year=%s", countryCode, year);
+
+        MvcResult response = mockMvc
+            .perform(get(url).contentType("application/json"))
+            .andExpect(status().isOk()).andReturn();
+
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(fakeJsonResult, responseString);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryServiceTests.java
@@ -20,6 +20,7 @@ public class PublicHolidayQueryServiceTests {
     @Autowired
     private PublicHolidayQueryService publicHolidayQueryService;
 
+    
     @Test
     public void test_getJSON() {
         String year = "2024";

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryServiceTests.java
@@ -1,0 +1,39 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(PublicHolidayQueryService.class)
+public class PublicHolidayQueryServiceTests {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private PublicHolidayQueryService publicHolidayQueryService;
+
+    @Test
+    public void test_getJSON() {
+        String year = "2024";
+        String countryCode = "US";
+        String expectedURL = PublicHolidayQueryService.ENDPOINT.replace("{year}", year).replace("{countryCode}", countryCode);
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = publicHolidayQueryService.getJSON(year, countryCode);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+}


### PR DESCRIPTION
In this PR, we added the PublicHolidayQueryServiceController and added its corresponding test. In this PR, we add an endpoint /api/publicholidays/get that can be used to get a holiday of any given date

dev deployment link:
http://team01-haojustin-dev.dokku-05.cs.ucsb.edu/swagger-ui/index.html
http://team01-haojustin-dev.dokku-05.cs.ucsb.edu/

closes #11 